### PR TITLE
Add ability to place buoys as checkpoint markers when in a boat

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -2,6 +2,7 @@ local QBCore = exports['qb-core']:GetCoreObject()
 local Countdown = 10
 local ToFarCountdown = 10
 local FinishedUITimeout = false
+local DefaultCheckpointPropName = "prop_offroad_tyres02"
 
 local RaceData = {
     InCreator = false,
@@ -33,14 +34,16 @@ AddEventHandler('onResourceStop', function(resource)
         for k, _ in pairs(CreatorData.Checkpoints) do
             if CreatorData.Checkpoints[k].pileleft ~= nil then
                 local coords = CreatorData.Checkpoints[k].offset.right
-                local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, `prop_offroad_tyres02`, 0, 0, 0)
+                local propName = CreatorData.Checkpoints[k].propName or DefaultCheckpointPropName
+                local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, GetHashKey(propName), 0, 0, 0)
                 DeleteObject(Obj)
                 ClearAreaOfObjects(coords.x, coords.y, coords.z, 50.0, 0)
                 CreatorData.Checkpoints[k].pileright = nil
             end
             if CreatorData.Checkpoints[k].pileright ~= nil then
                 local coords = CreatorData.Checkpoints[k].offset.right
-                local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, `prop_offroad_tyres02`, 0, 0, 0)
+                local propName = CreatorData.Checkpoints[k].propName or DefaultCheckpointPropName
+                local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, GetHashKey(propName), 0, 0, 0)
                 DeleteObject(Obj)
                 ClearAreaOfObjects(coords.x, coords.y, coords.z, 50.0, 0)
                 CreatorData.Checkpoints[k].pileright = nil
@@ -51,14 +54,16 @@ AddEventHandler('onResourceStop', function(resource)
             if CurrentRaceData.Checkpoints[k] ~= nil then
                 if CurrentRaceData.Checkpoints[k].pileleft ~= nil then
                     local coords = CurrentRaceData.Checkpoints[k].offset.right
-                    local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, `prop_offroad_tyres02`, 0, 0, 0)
+                    local propName = CurrentRaceData.Checkpoints[k].propName or DefaultCheckpointPropName
+                    local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, GetHashKey(propName), 0, 0, 0)
                     DeleteObject(Obj)
                     ClearAreaOfObjects(coords.x, coords.y, coords.z, 50.0, 0)
                     CurrentRaceData.Checkpoints[k].pileright = nil
                 end
                 if CurrentRaceData.Checkpoints[k].pileright ~= nil then
                     local coords = CurrentRaceData.Checkpoints[k].offset.right
-                    local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, `prop_offroad_tyres02`, 0, 0, 0)
+                    local propName = CurrentRaceData.Checkpoints[k].propName or DefaultCheckpointPropName
+                    local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, GetHashKey(propName), 0, 0, 0)
                     DeleteObject(Obj)
                     ClearAreaOfObjects(coords.x, coords.y, coords.z, 50.0, 0)
                     CurrentRaceData.Checkpoints[k].pileright = nil
@@ -139,14 +144,16 @@ local function DeleteCheckpoint()
             end
             if CreatorData.Checkpoints[RaceData.ClosestCheckpoint].pileleft ~= nil then
                 local coords = CreatorData.Checkpoints[RaceData.ClosestCheckpoint].offset.left
-                local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, `prop_offroad_tyres02`, 0, 0, 0)
+                local propName = CreatorData.Checkpoints[RaceData.ClosestCheckpoint].propName or DefaultCheckpointPropName
+                local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, GetHashKey(propName), 0, 0, 0)
                 DeleteObject(Obj)
                 ClearAreaOfObjects(coords.x, coords.y, coords.z, 50.0, 0)
                 CreatorData.Checkpoints[RaceData.ClosestCheckpoint].pileleft = nil
             end
             if CreatorData.Checkpoints[RaceData.ClosestCheckpoint].pileright ~= nil then
                 local coords = CreatorData.Checkpoints[RaceData.ClosestCheckpoint].offset.right
-                local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, `prop_offroad_tyres02`, 0, 0, 0)
+                local propName = CreatorData.Checkpoints[RaceData.ClosestCheckpoint].propName or DefaultCheckpointPropName
+                local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, GetHashKey(propName), 0, 0, 0)
                 DeleteObject(Obj)
                 ClearAreaOfObjects(coords.x, coords.y, coords.z, 50.0, 0)
                 CreatorData.Checkpoints[RaceData.ClosestCheckpoint].pileright = nil
@@ -190,14 +197,16 @@ local function SaveRace()
         if CreatorData.Checkpoints[id] ~= nil then
             if CreatorData.Checkpoints[id].pileleft ~= nil then
                 local coords = CreatorData.Checkpoints[id].offset.left
-                local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, `prop_offroad_tyres02`, 0, 0, 0)
+                local propName = CreatorData.Checkpoints[id].propName or DefaultCheckpointPropName
+                local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, GetHashKey(propName), 0, 0, 0)
                 DeleteObject(Obj)
                 ClearAreaOfObjects(coords.x, coords.y, coords.z, 50.0, 0)
                 CreatorData.Checkpoints[id].pileleft = nil
             end
             if CreatorData.Checkpoints[id].pileright ~= nil then
                 local coords = CreatorData.Checkpoints[id].offset.right
-                local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, `prop_offroad_tyres02`, 0, 0, 0)
+                local propName = CreatorData.Checkpoints[id].propName or DefaultCheckpointPropName
+                local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, GetHashKey(propName), 0, 0, 0)
                 DeleteObject(Obj)
                 ClearAreaOfObjects(coords.x, coords.y, coords.z, 50.0, 0)
                 CreatorData.Checkpoints[id].pileright = nil
@@ -214,6 +223,14 @@ local function AddCheckpoint()
     local PlayerPed = PlayerPedId()
     local PlayerPos = GetEntityCoords(PlayerPed)
     local PlayerVeh = GetVehiclePedIsIn(PlayerPed)
+    local IsPlayerInBoat = GetVehicleClass(PlayerVeh) == 14 -- 14 is the class for boats
+    local CheckpointPropName = DefaultCheckpointPropName
+
+    -- If the player is in a boat, place the buoy checkpoint prop
+    if IsPlayerInBoat then
+      CheckpointPropName = "prop_dock_bouy_1"
+    end
+
     local Offset = {
         left = {
             x = (GetOffsetFromEntityInWorldCoords(PlayerVeh, -CreatorData.TireDistance, 0.0, 0.0)).x,
@@ -234,6 +251,7 @@ local function AddCheckpoint()
             z = PlayerPos.z,
         },
         offset = Offset,
+        propName = CheckpointPropName,
     }
 
 
@@ -318,7 +336,8 @@ local function CreatorLoop()
                     for id,_ in pairs(CreatorData.Checkpoints) do
                         if CreatorData.Checkpoints[id].pileleft ~= nil then
                             local coords = CreatorData.Checkpoints[id].offset.left
-                            local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 8.0, `prop_offroad_tyres02`, 0, 0, 0)
+                            local propName = CreatorData.Checkpoints[id].propName or DefaultCheckpointPropName
+                            local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 8.0, GetHashKey(propName), 0, 0, 0)
                             DeleteObject(Obj)
                             ClearAreaOfObjects(coords.x, coords.y, coords.z, 50.0, 0)
                             CreatorData.Checkpoints[id].pileleft = nil
@@ -326,7 +345,8 @@ local function CreatorLoop()
 
                         if CreatorData.Checkpoints[id].pileright ~= nil then
                             local coords = CreatorData.Checkpoints[id].offset.right
-                            local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 8.0, `prop_offroad_tyres02`, 0, 0, 0)
+                            local propName = CreatorData.Checkpoints[id].propName or DefaultCheckpointPropName
+                            local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 8.0, GetHashKey(propName), 0, 0, 0)
                             DeleteObject(Obj)
                             ClearAreaOfObjects(coords.x, coords.y, coords.z, 50.0, 0)
                             CreatorData.Checkpoints[id].pileright = nil
@@ -410,13 +430,13 @@ local function SetupRace(sRaceData, Laps)
 
     for k, v in pairs(CurrentRaceData.Checkpoints) do
         ClearAreaOfObjects(v.offset.left.x, v.offset.left.y, v.offset.left.z, 50.0, 0)
-        CurrentRaceData.Checkpoints[k].pileleft = CreateObject(`prop_offroad_tyres02`, v.offset.left.x, v.offset.left.y, v.offset.left.z, 0, 0, 0)
+        CurrentRaceData.Checkpoints[k].pileleft = CreateObject(GetHashKey(v.propName or DefaultCheckpointPropName), v.offset.left.x, v.offset.left.y, v.offset.left.z, 0, 0, 0)
         PlaceObjectOnGroundProperly(CurrentRaceData.Checkpoints[k].pileleft)
         FreezeEntityPosition(CurrentRaceData.Checkpoints[k].pileleft, 1)
         SetEntityAsMissionEntity(CurrentRaceData.Checkpoints[k].pileleft, 1, 1)
 
         ClearAreaOfObjects(v.offset.right.x, v.offset.right.y, v.offset.right.z, 50.0, 0)
-        CurrentRaceData.Checkpoints[k].pileright = CreateObject(`prop_offroad_tyres02`, v.offset.right.x, v.offset.right.y, v.offset.right.z, 0, 0, 0)
+        CurrentRaceData.Checkpoints[k].pileright = CreateObject(GetHashKey(v.propName or DefaultCheckpointPropName), v.offset.right.x, v.offset.right.y, v.offset.right.z, 0, 0, 0)
         PlaceObjectOnGroundProperly(CurrentRaceData.Checkpoints[k].pileright)
         FreezeEntityPosition(CurrentRaceData.Checkpoints[k].pileright, 1)
         SetEntityAsMissionEntity(CurrentRaceData.Checkpoints[k].pileright, 1, 1)
@@ -465,7 +485,7 @@ local function SetupPiles()
     for k, v in pairs(CreatorData.Checkpoints) do
         if CreatorData.Checkpoints[k].pileleft == nil then
             ClearAreaOfObjects(v.offset.left.x, v.offset.left.y, v.offset.left.z, 50.0, 0)
-            CreatorData.Checkpoints[k].pileleft = CreateObject(`prop_offroad_tyres02`, v.offset.left.x, v.offset.left.y, v.offset.left.z, 0, 0, 0)
+            CreatorData.Checkpoints[k].pileleft = CreateObject(GetHashKey(v.propName or DefaultCheckpointPropName), v.offset.left.x, v.offset.left.y, v.offset.left.z, 0, 0, 0)
             PlaceObjectOnGroundProperly(CreatorData.Checkpoints[k].pileleft)
             FreezeEntityPosition(CreatorData.Checkpoints[k].pileleft, 1)
             SetEntityAsMissionEntity(CreatorData.Checkpoints[k].pileleft, 1, 1)
@@ -473,7 +493,7 @@ local function SetupPiles()
 
         if CreatorData.Checkpoints[k].pileright == nil then
             ClearAreaOfObjects(v.offset.right.x, v.offset.right.y, v.offset.right.z, 50.0, 0)
-            CreatorData.Checkpoints[k].pileright = CreateObject(`prop_offroad_tyres02`, v.offset.right.x, v.offset.right.y, v.offset.right.z, 0, 0, 0)
+            CreatorData.Checkpoints[k].pileright = CreateObject(GetHashKey(v.propName or DefaultCheckpointPropName), v.offset.right.x, v.offset.right.y, v.offset.right.z, 0, 0, 0)
             PlaceObjectOnGroundProperly(CreatorData.Checkpoints[k].pileright)
             FreezeEntityPosition(CreatorData.Checkpoints[k].pileleft, 1)
             SetEntityAsMissionEntity(CreatorData.Checkpoints[k].pileleft, 1, 1)
@@ -518,14 +538,16 @@ local function FinishRace()
         end
         if CurrentRaceData.Checkpoints[k].pileleft ~= nil then
             local coords = CurrentRaceData.Checkpoints[k].offset.left
-            local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, `prop_offroad_tyres02`, 0, 0, 0)
+            local propName = CurrentRaceData.Checkpoints[k].propName or DefaultCheckpointPropName
+            local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, GetHashKey(propName), 0, 0, 0)
             DeleteObject(Obj)
             ClearAreaOfObjects(coords.x, coords.y, coords.z, 50.0, 0)
             CurrentRaceData.Checkpoints[k].pileleft = nil
         end
         if CurrentRaceData.Checkpoints[k].pileright ~= nil then
             local coords = CurrentRaceData.Checkpoints[k].offset.right
-            local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, `prop_offroad_tyres02`, 0, 0, 0)
+            local propName = CurrentRaceData.Checkpoints[k].propName or DefaultCheckpointPropName
+            local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, GetHashKey(propName), 0, 0, 0)
             DeleteObject(Obj)
             ClearAreaOfObjects(coords.x, coords.y, coords.z, 50.0, 0)
             CurrentRaceData.Checkpoints[k].pileright = nil
@@ -609,14 +631,16 @@ RegisterNetEvent('qb-lapraces:client:LeaveRace', function(_)
         end
         if CurrentRaceData.Checkpoints[k].pileleft ~= nil then
             local coords = CurrentRaceData.Checkpoints[k].offset.left
-            local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, `prop_offroad_tyres02`, 0, 0, 0)
+            local propName = CurrentRaceData.Checkpoints[k].propName or DefaultCheckpointPropName
+            local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, GetHashKey(propName), 0, 0, 0)
             DeleteObject(Obj)
             ClearAreaOfObjects(coords.x, coords.y, coords.z, 50.0, 0)
             CurrentRaceData.Checkpoints[k].pileleft = nil
         end
         if CurrentRaceData.Checkpoints[k].pileright ~= nil then
             local coords = CurrentRaceData.Checkpoints[k].offset.right
-            local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, `prop_offroad_tyres02`, 0, 0, 0)
+            local propName = CurrentRaceData.Checkpoints[k].propName or DefaultCheckpointPropName
+            local Obj = GetClosestObjectOfType(coords.x, coords.y, coords.z, 5.0, GetHashKey(propName), 0, 0, 0)
             DeleteObject(Obj)
             ClearAreaOfObjects(coords.x, coords.y, coords.z, 50.0, 0)
             CurrentRaceData.Checkpoints[k].pileright = nil

--- a/server/main.lua
+++ b/server/main.lua
@@ -459,7 +459,8 @@ RegisterNetEvent('qb-lapraces:server:SaveRace', function(RaceData)
     for k, v in pairs(RaceData.Checkpoints) do
         Checkpoints[k] = {
             offset = v.offset,
-            coords = v.coords
+            coords = v.coords,
+            propName = v.propName or "prop_offroad_tyres02",
         }
     end
     Races[RaceId] = {


### PR DESCRIPTION
**Describe Pull request**
This PR adds the ability to extend races into the water by using buoys as the checkpoint markers. A race can now either happen on land, on water or a combination of both.

When placing the markers, we simply check if the player is in a boat, if they are we use the buoy prop instead of the tires. We also save the propName in the data for each Checkpoint. At the time of displaying the checkpoints, we read from the Checkpoint.propName for which prop to use. If for whatever reason it is not defined, we'll always fallback to using the tires.

![image](https://user-images.githubusercontent.com/18689469/188793791-dd0bf6bf-b470-4379-801d-a1ace7b56249.png)


**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
