### PR TITLE
Fix for Warning: Could not find file

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -19,8 +19,6 @@ files {
     'html/*.html',
     'html/*.css',
     'html/*.js',
-    'html/fonts/*.otf',
-    'html/img/*'
 }
 
 lua54 'yes'


### PR DESCRIPTION
This fixes the console warning being thrown when starting the script.