### PR TITLE
Use previously generated race id when inserting into db

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -476,7 +476,7 @@ RegisterNetEvent('qb-lapraces:server:SaveRace', function(RaceData)
     }
     MySQL.insert('INSERT INTO lapraces (name, checkpoints, creator, distance, raceid) VALUES (?, ?, ?, ?, ?)',
         {RaceData.RaceName, json.encode(Checkpoints), Player.PlayerData.citizenid, RaceData.RaceDistance,
-         GenerateRaceId()})
+            RaceId )})
 end)
 
 -- Callbacks


### PR DESCRIPTION
**Describe Pull request**
This fixes an issue that would prevent the creation of races with newly added tracks (at least via the [NWPD qb_racing app](https://github.com/npwd-community/npwd_qb_racing)). The problem was two separate Race Ids were getting generated, leading to the in-memory cache and the database table being out of sync.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
